### PR TITLE
setup deployment to vercel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,56 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
+const ContentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is;
+  style-src 'self' 'unsafe-inline';
+  img-src * blob: data:;
+  media-src *.s3.amazonaws.com;
+  connect-src *;
+  font-src 'self';
+  frame-src giscus.app
+`;
 
-module.exports = nextConfig;
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value: ContentSecurityPolicy.replace(/\n/g, ""),
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "X-DNS-Prefetch-Control",
+    value: "on",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+];
+
+/**
+ * @type {import('next/dist/next-server/server/config').NextConfig}
+ **/
+module.exports = {
+  reactStrictMode: true,
+  pageExtensions: ["ts", "tsx", "js", "jsx", "md", "mdx"],
+  eslint: {
+    dirs: ["app", "components", "layouts", "scripts"],
+  },
+  images: { domains: ["picsum.photos"] },
+  async headers() {
+    return [{ source: "/(.*)", headers: securityHeaders }];
+  },
+};


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a set of security headers to the `next.config.js` file. These headers will help to improve the security of the application by enforcing certain browser features and behaviors.
> 
> ## What changed
> The `next.config.js` file was updated to include a `ContentSecurityPolicy` and a `securityHeaders` array. The `ContentSecurityPolicy` defines the sources from which certain types of content can be loaded. The `securityHeaders` array includes a set of headers that enforce certain security features and behaviors in the browser.
> 
> The `module.exports` was also updated to include `reactStrictMode`, `pageExtensions`, `eslint`, `images`, and `headers` configurations.
> 
> ## How to test
> To test these changes, you can run the application and inspect the headers of the HTTP response using the browser's developer tools. You should see the security headers defined in the `securityHeaders` array in the response headers.
> 
> ## Why make this change
> These changes were made to improve the security of the application. The `ContentSecurityPolicy` helps to prevent cross-site scripting (XSS) attacks by defining the sources from which certain types of content can be loaded. The security headers enforce certain security features and behaviors in the browser, such as preventing the browser from interpreting files as a different MIME type to what is declared in the `Content-Type` header (`X-Content-Type-Options: nosniff`), and preventing the page from being displayed in a frame (`X-Frame-Options: DENY`).
</details>